### PR TITLE
Fix schedule time sorting for class sessions

### DIFF
--- a/app/utils/schedule.ts
+++ b/app/utils/schedule.ts
@@ -33,6 +33,12 @@ export const formatTime = (time: string) => {
     return `${displayHour}:${minutes} ${ampm}`;
 };
 
+// Convert a 24-hour time string ("HH:MM") to minutes
+const timeStringToMinutes = (time: string) => {
+    const [h, m] = time.split(":").map(Number);
+    return h * 60 + m;
+};
+
 // Helper function to calculate end time from start time and duration
 export const calculateEndTime = (startTime: string, durationMinutes: number) => {
     const [hours, minutes] = startTime.split(':').map(Number);
@@ -147,10 +153,14 @@ export const getScheduleInfo = (classes: ClassWithSchedule[]) => {
     // Get the time range (earliest start to latest end)
     const allTimes = Object.values(sessionsByDay).flat();
     if (allTimes.length > 0) {
-        const earliestStart = allTimes.map(t => t.start).sort()[0];
-        const latestEnd = allTimes.map(t => t.end).sort().reverse()[0];
+        const earliestStart = allTimes
+            .map(t => t.start)
+            .sort((a, b) => timeStringToMinutes(a) - timeStringToMinutes(b))[0];
+        const latestEnd = allTimes
+            .map(t => t.end)
+            .sort((a, b) => timeStringToMinutes(b) - timeStringToMinutes(a))[0];
         const times = `${formatTime(earliestStart)} - ${formatTime(latestEnd)}`;
-        
+
         return {
             days: days || siteConfig.classes.days,
             times: times
@@ -233,10 +243,12 @@ export const getOpeningHoursSpecification = (classes: ClassWithSchedule[]) => {
     return Object.entries(sessionsByDay).map(([day, timeSlots]) => {
         const startTimes = timeSlots.map(slot => slot.start);
         const endTimes = timeSlots.map(slot => slot.end);
-        
-        const earliestStart = startTimes.sort()[0];
-        const latestEnd = endTimes.sort().reverse()[0];
-        
+
+        const earliestStart = startTimes
+            .sort((a, b) => timeStringToMinutes(a) - timeStringToMinutes(b))[0];
+        const latestEnd = endTimes
+            .sort((a, b) => timeStringToMinutes(b) - timeStringToMinutes(a))[0];
+
         return {
             "@type": "OpeningHoursSpecification",
             "dayOfWeek": [day],


### PR DESCRIPTION
## Summary
- ensure schedule utilities compare times numerically instead of lexically
- expose helper to convert HH:MM strings to minutes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 55 errors, 16 warnings)*
- `npx eslint app/utils/schedule.ts`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a5fe9d85e083229a601bc6c3277d98