### PR TITLE
refactor: use global fetch and assert in push verify test

### DIFF
--- a/test-push-verify.js
+++ b/test-push-verify.js
@@ -1,9 +1,13 @@
-const fetch = require('node:fetch');
+import assert from 'node:assert';
+
+// Use the built-in fetch available in modern Node versions or fall back to
+// node-fetch when running in older environments.
+const fetch = globalThis.fetch ?? (await import('node-fetch')).default;
 
 async function testPushVerify() {
   try {
     console.log('Testing POST request to /api/push/verify...');
-    
+
     const response = await fetch('http://localhost:5173/api/push/verify', {
       method: 'POST',
       headers: {
@@ -16,20 +20,19 @@ async function testPushVerify() {
 
     console.log('Response status:', response.status);
     console.log('Response headers:', Object.fromEntries(response.headers.entries()));
-    
+
     const responseText = await response.text();
     console.log('Response body:', responseText);
-    
-    if (response.status === 401) {
-      console.log('✓ Expected 401 Unauthorized (no auth token provided)');
-      console.log('✓ Route handler is working - no more "no action" error');
-    } else {
-      console.log('Response status:', response.status);
-    }
-    
+
+    // Ensure the route returns the expected status code so CI can detect issues.
+    assert.strictEqual(response.status, 401, 'Expected 401 Unauthorized (no auth token provided)');
+    console.log('✓ Expected 401 Unauthorized (no auth token provided)');
+    console.log('✓ Route handler is working - no more "no action" error');
   } catch (error) {
-    console.error('Error testing push verify:', error.message);
+    console.error('Error testing push verify:', error);
+    process.exit(1);
   }
 }
 
 testPushVerify();
+


### PR DESCRIPTION
## Summary
- remove `require('node:fetch')` and rely on global fetch with `node-fetch` fallback
- assert that `/api/push/verify` returns 401 and exit non-zero on failure

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node test-push-verify.js` *(fails: fetch failed ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68a60530481c8322aa9b1b693cf5d37f