### PR TITLE
Exclude admin test email route from TypeScript checks

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,15 @@
     // Vite takes care of building everything, not tsc.
     "noEmit": true
   },
-  "exclude": ["node_modules", "supabase/functions", "db-tools", "_scratch", "mcp_server", "e2e", "test-*.js", "test-*.cjs", "app/routes/admin.test-email.tsx"] // Exclude Deno functions, MCP server, e2e tests, and test files from tsc
+  "exclude": [
+    "node_modules",
+    "supabase/functions",
+    "db-tools",
+    "_scratch",
+    "mcp_server",
+    "e2e",
+    "test-*.js",
+    "test-*.cjs",
+    "app/routes/admin.test-email.tsx"
+  ] // Exclude Deno functions, MCP server, e2e tests, and test files from tsc
 }


### PR DESCRIPTION
## Summary
- format the `exclude` list in `tsconfig.json`
- ensure the admin test email route is excluded from TypeScript project checks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fcb85e8e6883229d8f8bc12108c6ca